### PR TITLE
Fix limit and yakuman tenpai flags calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,20 +84,20 @@ You need a pipenv and python 3.10+
 
 Clone this repository, install requrements and run with either:
 
-- `python main.py -l '<log url>'`
-- `python main.py -l '<log url>' -p <seat number 0-3>`
+- `python main.py '<log url>'`
+- `python main.py '<log url>' -p <seat number 0-3>`
 
 where 0 = East, 1 = South, 2 = West, 3 = North.
 
 Outputs injustices to console.
 
 To output skills use `-m skill`:
-- `python main.py -l '<log url>' -m skill`
-- `python main.py -l '<log url>' -p <seat number 0-3> -m skill`
+- `python main.py '<log url>' -m skill`
+- `python main.py '<log url>' -p <seat number 0-3> -m skill`
 
 To output both skills and injustice use `-m both`:
-- `python main.py -l '<log url>' -m both`
-- `python main.py -l '<log url>' -p <seat number 0-3> -m both`
+- `python main.py '<log url>' -m both`
+- `python main.py '<log url>' -p <seat number 0-3> -m both`
 
 ## Usage (library)
 

--- a/injustice_judge/classes2.py
+++ b/injustice_judge/classes2.py
@@ -445,7 +445,7 @@ class Kyoku:
     def get_starting_score(self) -> int:
         return (sum(self.start_scores) + self.rules.riichi_value*self.riichi_sticks) // self.num_players
     def get_visible_tiles(self) -> List[int]:
-        """Get all the currently visible tiles, used for ukeire calculations"""
+        """Get all the currently visible tiles on the board, used for ukeire calculations"""
         pond_tiles = [tile for seat in range(self.num_players) for tile in self.pond[seat]]
         dora_indicators = [to_dora_indicator(dora, self.num_players) for dora in self.doras if dora not in {51,52,53}][:self.num_dora_indicators_visible]
         def get_undiscarded_part(call):

--- a/injustice_judge/fetch/majsoul.py
+++ b/injustice_judge/fetch/majsoul.py
@@ -55,8 +55,8 @@ class MahjongSoulAPI:
         assert method is not None, f"couldn't find method {name}"
 
         # prepare the payload (req) and a place to store the response (res)
-        req: Message = pb.reflection.MakeClass(method.input_type)(**fields)  # type: ignore[attr-defined]
-        res: Message = pb.reflection.MakeClass(method.output_type)()  # type: ignore[attr-defined]
+        req: Message = pb.message_factory.GetMessageClass(method.input_type)(**fields)  # type: ignore[attr-defined]
+        res: Message = pb.message_factory.GetMessageClass(method.output_type)()  # type: ignore[attr-defined]
         # the Res* response must have an error field
         assert hasattr(res, "error"), f"Got non-Res object: {res}\n\nfrom request: {req}"
 
@@ -132,7 +132,7 @@ def parse_wrapped_bytes(data: bytes) -> Tuple[str, Message]:
     wrapper.ParseFromString(data)
     name = wrapper.name.strip(f'.{proto.DESCRIPTOR.package}')
     try:
-        msg = pb.reflection.MakeClass(proto.DESCRIPTOR.message_types_by_name[name])()  # type: ignore[attr-defined]
+        msg = pb.message_factory.GetMessageClass(proto.DESCRIPTOR.message_types_by_name[name])()  # type: ignore[attr-defined]
         msg.ParseFromString(wrapper.data)
     except KeyError as e:
         raise Exception(f"Failed to find message name {name}")

--- a/injustice_judge/fetch/postprocess.py
+++ b/injustice_judge/fetch/postprocess.py
@@ -25,6 +25,7 @@ def postprocess_events(all_events: List[List[Event]],
         kyoku: Kyoku = Kyoku(rules=metadata.rules, wall=wall, num_dora_indicators_visible=metadata.rules.starting_doras)
         shanten_before_last_draw: List[Shanten] = []
         flip_kan_dora_next_discard = False
+        add_riichi_stick_if_discard_passes = False
         def update_shanten(seat: int) -> None:
             old_shanten = shanten_before_last_draw[seat]
             new_shanten = kyoku.hands[seat].shanten
@@ -73,8 +74,6 @@ def postprocess_events(all_events: List[List[Event]],
                 kyoku.final_discard_event_index[seat] = len(kyoku.events) - 1
                 kyoku.pond[seat].append(tile)
                 update_shanten(seat)
-                if event_type == "riichi":
-                    kyoku.riichi_sticks += 1
             elif event_type in {"chii", "pon", "minkan"}: # calls
                 # process a call (which is like a special draw)
                 called_tile, call_tiles, call_dir = event_data
@@ -122,6 +121,13 @@ def postprocess_events(all_events: List[List[Event]],
                     kyoku.num_dora_indicators_visible += 1
                 else:
                     flip_kan_dora_next_discard = True
+            # if event was a riichi discard, check if it dealt in before placing the riichi stick on the table
+            if event_type == "riichi":
+                add_riichi_stick_if_discard_passes = True
+            elif add_riichi_stick_if_discard_passes:
+                if event_type != "end_game":
+                    kyoku.riichi_sticks += 1
+                add_riichi_stick_if_discard_passes = False
         assert len(kyoku.hands) > 0, f"somehow we never initialized the kyoku at index {len(kyokus)}"
         if len(kyokus) == 0:
             assert (kyoku.round, kyoku.honba) == (0, 0), f"kyoku numbering didn't start with East 1: instead it's {round_name(kyoku.round, kyoku.honba)}"

--- a/injustice_judge/flags.py
+++ b/injustice_judge/flags.py
@@ -736,8 +736,8 @@ class KyokuState:
         # if no calls, use tsumo score. else, get ron score
         calls_present = len(get_yaku_args["hand"].calls) > 0  # type: ignore[attr-defined]
         all_scores = get_yaku(**get_yaku_args, check_rons = calls_present, check_tsumos = not calls_present)  # type: ignore[arg-type]
-        visible_tiles = self.kyoku.get_visible_tiles()
-        formatted_scores = [(score, wait) for wait, score in all_scores.items() if visible_tiles.count(wait) > 0]
+        normalized_visible_tiles = list(normalize_red_fives(self.kyoku.get_visible_tiles() + list(hand.closed_part)))
+        formatted_scores = [(score, wait) for wait, score in all_scores.items() if normalized_visible_tiles.count(wait) < 4]
         if len(formatted_scores) > 0: # if wait is not dead
             best_score, takame = max(formatted_scores)
             han = best_score.han
@@ -748,7 +748,7 @@ class KyokuState:
             recalculate = han in {7, 9, 10, 12} or is_mangan(han-1, fu)
             if recalculate and not calls_present:
                 ron_scores = get_yaku(**get_yaku_args, check_rons = True, check_tsumos = False)  # type: ignore[arg-type]
-                formatted_ron_scores = [(score, wait) for wait, score in ron_scores.items() if visible_tiles.count(wait) > 0]
+                formatted_ron_scores = [(score, wait) for wait, score in ron_scores.items() if normalized_visible_tiles.count(wait) < 4]
                 if len(formatted_ron_scores) > 0: # if wait is not dead
                     best_ron_score, ron_takame = max(formatted_ron_scores)
                     ron_han = best_score.han
@@ -772,8 +772,7 @@ class KyokuState:
             # first, do standard yakuman, otherwise, try kazoe yakuman
             yakuman_waits: List[Tuple[str, Set[int]]] = [(y, get_yakuman_waits(self.at[seat].hand, y)) for y in get_yakuman_tenpais(self.at[seat].hand)]
             # only report the yakuman if the waits are not dead
-            visible = self.get_visible_tiles()
-            yakuman_types: Set[str] = {t for t, waits in yakuman_waits if not all(visible.count(wait) == 4 for wait in waits)}
+            yakuman_types: Set[str] = {t for t, waits in yakuman_waits if not all(normalized_visible_tiles.count(wait) == 4 for wait in waits)}
             if len(yakuman_types) > 0:
                 self.add_flag(seat, Flags.YOU_REACHED_YAKUMAN_TENPAI, {"hand": self.at[seat].hand, "types": yakuman_types, "waits": yakuman_waits})
             elif han >= 13 and not any(y in YAKUMAN for y, _ in best_score.yaku):


### PR DESCRIPTION
Fixed calculation for Flags.YOU_HAD_LIMIT_TENPAI and Flags.YOU_REACHED_YAKUMAN_TENPAI. Instead of checking to exclude dead waits as intended, they were excluding waits without visible tiles on the table. I've fixed this and made them properly count concealed tiles in hand and red fives.

I also replaced some calls to deprecated protobuf methods that the Python library no longer supports.